### PR TITLE
Change msgtype from m.notice to m.text

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -78,7 +78,7 @@ post '/hook' do
     next unless client.is_a? MatrixSdk::Api
 
     client.send_message_event(room, 'm.room.message',
-                              msgtype: 'm.notice',
+                              msgtype: 'm.text',
                               body: plain,
                               formatted_body: html,
                               format: 'org.matrix.custom.html')


### PR DESCRIPTION
Isn't the idea to get notified?
If not it's still possible to just mute the room.